### PR TITLE
Adds Chaska IFSC, Dublin

### DIFF
--- a/IE-Dublin.md
+++ b/IE-Dublin.md
@@ -1,3 +1,4 @@
 Indian
 -------
+* [Chaska IFSC](https://www.facebook.com/chaskaifsc): Authentic indian dining in Mayor Square, IFSC. Available for delivery via [Deliveroo](https://deliveroo.ie/menu/dublin/financial-services-centre/chaska) and [Just Eat](https://www.just-eat.ie/restaurants-ChaskaKitchen-Dublin/menu), and collection. Open 11am-11pm.
 * [Kerala Kitchen](https://www.keralakitchen.ie/): Fine, fresh Indian food restaurant and takeaway in Upper Baggot Street. Minimum order for lunchtime delivery €50. Available for delivery and collection. Deliveries on average take 45-60 min & collections get ready in 20-25 min.


### PR DESCRIPTION
Adding [Chaska IFSC](https://www.facebook.com/chaskaifsc/about) to Indian restaurants in Dublin